### PR TITLE
add arm64 support for loading libraries

### DIFF
--- a/src/libloader.c
+++ b/src/libloader.c
@@ -45,7 +45,7 @@ int	LoadCupsLibrary(CUPSLIB_FUNCTION* cupsfun)
 		"/usr/local/lib/libcups.dylib",
 		"/usr/local/lib/libcups.2.dylib",
 #else
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 		// try 64 bit libraries on 64 bit system
 		"/usr/lib64/libcups.so",
 		"/usr/lib64/libcups.so.2",
@@ -250,7 +250,7 @@ int	LoadGsLibrary(GSLIB_FUNCTION* gsfun)
 		"/usr/lib/libgs.8.dylib",
 		"/usr/local/lib/libgs.dylib",
 		"/usr/local/lib/libgs.8.dylib",
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		// try 64 bit libraries on 64 bit system
 		"/usr/lib64/libgs.so",
 		"/usr/lib64/libgs.so.8",


### PR DESCRIPTION
arm64 machines were falling into the 32-bit case.  Add a check for arm64 as well as x86_64.